### PR TITLE
fix: no hardcoded auth API_URL remains in authService

### DIFF
--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -1,4 +1,4 @@
-const API_URL = 'http://localhost:8080/api/v1';
+import { buildApiPath } from "../utils/constants";
 
 export interface AuthResult
 {
@@ -60,7 +60,7 @@ export const authService =
     try
     {
       const response = await fetch(
-        `${API_URL}/login`,
+        buildApiPath('/login'),
         {method: 'POST',
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify({username, password})
@@ -93,7 +93,7 @@ export const authService =
     try
     {
       const response = await fetch(
-        `${API_URL}/register`,
+        buildApiPath('/register'),
         {method: 'POST',
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify({username, password, email})
@@ -124,7 +124,7 @@ export const authService =
   {
     try
     {
-      const response = await fetch(`${API_URL}/user/me`,
+      const response = await fetch(buildApiPath('/user/me'),
       {
         method: 'GET',
         headers: {

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -1,10 +1,8 @@
 export const buildApiPath = (path: string): string => {
- // * VITE_BACKEND_URL missing/already include /api/vi -> normalize once so final API paths are always: <origin>/api/v1/<route>
+    // Normalize VITE_BACKEND_URL once so API paths are always: <origin>/api/v1/<route>.
+    // with support to env being missing or already including /api/v1.
     const backendOrigin = (import.meta.env.VITE_BACKEND_URL || 'http://localhost:8080')
         .replace(/\/+$/, '')
         .replace(/\/api\/v1$/, '');
     return `${backendOrigin}/api/v1${path}`;
 }
-
-// VITE_BACKEND_URL missing -> undefined/api/v1/user/me/settings/avatar (connection error)
-// VITE_BACKEND_URL=http://localhost:8080/api/v1 -> http://localhost:8080/api/v1/api/v1/user/me/settings/avatar (404)


### PR DESCRIPTION
i replaced hardcoded auth base URL in "authService.ts"  with buildApiPath.
if i got it right that was the problem?